### PR TITLE
Fixes duplicate content-length header in older versions of libcurl

### DIFF
--- a/lib/LWP/Protocol/Net/Curl.pm
+++ b/lib/LWP/Protocol/Net/Curl.pm
@@ -200,7 +200,14 @@ sub _handle_method {
             $easy->setopt(CURLOPT_UPLOAD    ,=> 1);
             my $buf = $request->content;
             my $off = 0;
+            # Do not set CURLOPT_INFILESIZE if Content-Length header exists
+            # and libcurl version is earlier than 7.23.0 (note libcurl will
+            # send two Content-Length headers in versions earlier than 7.23.0
+            # when both the Content-Length header and CURLOPT_INFILESIZE
+            # option is set).
             $easy->setopt(CURLOPT_INFILESIZE,=> length $buf);
+              if ! defined $request->header('content-length')
+                || Net::Curl::version_info()->{version_num} >= 464640;            
             $easy->setopt(CURLOPT_READFUNCTION ,=> sub {
                 my (undef, $maxlen) = @_;
                 my $chunk = substr $buf, $off, $maxlen;


### PR DESCRIPTION
Libcurl incorrectly sends two Content-Length headers for HTTP PUT requests in versions older than 7.23.0 when both the Content-Length header is already defined and the CURLOPT_INFILESIZE option is set.  Note, in versions 7.23.0 and later, a single Content-Length header is sent which is the correct behavior.  This pull request conditionally sets the CURLOPT_INFILESIZE option for HTTP PUT requests such that it will not be set if the Content-Length header is already defined and the version is older than 7.23.0.  This change allows existing Perl code to send valid HTTP PUT requests with this module when using older versions of libcurl without having to modify the original code.

The following Perl code, which sends a sample PUT request to port 80 on localhost, can be used to see the duplicate Content-Length headers that libcurl incorrectly sends.  Simply run this code on a machine which contains a version of libcurl earlier than 7.23.0 and you will see two Content-Length headers.

```
use strict;
use warnings;
use HTTP::Request;
use LWP::UserAgent;
use LWP::Protocol::Net::Curl verbose => 1;

my $ua = LWP::UserAgent->new();
my $content = '<test>some test content</test>';
$ua->request(
  HTTP::Request->new(
    'PUT',
    "http://localhost/",
    [ 
      'Content-Type' => 'text/xml',
      'Content-Length' => length $content,
    ],
    $content
  )
);
```
